### PR TITLE
Bug 1745532: FlattenListVisitor now continues traversal on errors and returns an aggregate

### DIFF
--- a/pkg/resource/visitor.go
+++ b/pkg/resource/visitor.go
@@ -367,10 +367,9 @@ func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
 
 // FlattenListVisitor flattens any objects that runtime.ExtractList recognizes as a list
 // - has an "Items" public field that is a slice of runtime.Objects or objects satisfying
-// that interface - into multiple Infos. An error on any sub item (for instance, if a List
-// contains an object that does not have a registered client or resource) will terminate
-// the visit.
-// TODO: allow errors to be aggregated?
+// that interface - into multiple Infos. Returns nil in the case of no errors.
+// When an error is hit on sub items (for instance, if a List contains an object that does
+// not have a registered client or resource), returns an aggregate error.
 type FlattenListVisitor struct {
 	visitor Visitor
 	typer   runtime.ObjectTyper
@@ -421,19 +420,21 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 			preferredGVKs = append(preferredGVKs, info.Mapping.GroupVersionKind)
 		}
 
+		errs := []error{}
 		for i := range items {
 			item, err := v.mapper.infoForObject(items[i], v.typer, preferredGVKs)
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 			if len(info.ResourceVersion) != 0 {
 				item.ResourceVersion = info.ResourceVersion
 			}
 			if err := fn(item, nil); err != nil {
-				return err
+				errs = append(errs, err)
 			}
 		}
-		return nil
+		return utilerrors.NewAggregate(errs)
 	})
 }
 


### PR DESCRIPTION
This fixes a problem that `FlattenListVisitor` would always return an error as soon as it hit one in list traversal, even if `ContinueOnError` is specified

BZ: 4.2: https://bugzilla.redhat.com/show_bug.cgi?id=1745532
Upstream PR: https://github.com/kubernetes/kubernetes/pull/81452